### PR TITLE
og:imageのURLをGitHub pagesのものへと変更

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -16,7 +16,7 @@
 	<meta property="og:type" content="website" />
 	<meta property="og:title" content="OSHIRASE" />
 	<meta property="og:url" content="http://monsier-oui.github.io/OSHIRASE/" />
-	<meta property="og:image" content="https://raw.githubusercontent.com/monsier-oui/OSHIRASE/gh-pages/img/image.png" />
+	<meta property="og:image" content="http://monsier-oui.github.io/OSHIRASE/img/image.png" />
 	<meta property="og:description" content="アンソロジーや合同誌の特設サイト向けHTMLテンプレート">
 	<meta property="twitter:card" content="summary" />
 	<meta property="twitter:site" content="@oui_" />

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
 	<meta property="og:type" content="website" />
 	<meta property="og:title" content="OSHIRASE" />
 	<meta property="og:url" content="http://monsier-oui.github.io/OSHIRASE/" />
-	<meta property="og:image" content="https://raw.githubusercontent.com/monsier-oui/OSHIRASE/gh-pages/img/image.png" />
+	<meta property="og:image" content="http://monsier-oui.github.io/OSHIRASE/img/image.png" />
 	<meta property="og:description" content="アンソロジーや合同誌の特設サイト向けHTMLテンプレート">
 	<meta property="twitter:card" content="summary" />
 	<meta property="twitter:site" content="@oui_" />


### PR DESCRIPTION
こんにちわ。

https://raw.githubusercontent.com/monsier-oui/OSHIRASE/gh-pages/img/image.png

gh-pagesブランチの画像を直接参照していたのを

http://monsier-oui.github.io/OSHIRASE/img/image.png

と、GitHub pages上のURLへと変更しました。

画像の場合は、どちらでも問題なく表示されるためあまり神経質になる必要はありませんが、
他のファイルに合わせて、`github.io`のURLに揃えた方がいいかなと思います。
(`raw.githubusercontent.com`上のファイルをウェブサイトで直接表示するのはあまり推奨されていません)

JavaScriptファイルの場合は以下のように、`raw.githubusercontent.com`の方を使ってしまうと
読み込みできないという問題が起きるので、その意味でも`github.io`のURLに揃えたほうが適切かなと思います。

``` html
<script src="https://raw.githubusercontent.com/monsier-oui/OSHIRASE/gh-pages/js/func.js"></script>
```
